### PR TITLE
Add vehicle impact to RestrictionRoadEvent

### DIFF
--- a/schemas/v1.1/RoadEventFeature.json
+++ b/schemas/v1.1/RoadEventFeature.json
@@ -80,6 +80,9 @@
               "items": {
                 "$ref": "#/definitions/Lane"
               }
+            },
+            "vehicle_impact": {
+              "$ref": "#/definitions/VehicleImpact"
             }
           },
           "required": [

--- a/schemas/v1.1/RoadEventFeature.json
+++ b/schemas/v1.1/RoadEventFeature.json
@@ -294,7 +294,7 @@
       "title": "Unit of Measurement Enumerated Type",
       "description": "Unit of measurement, used when providing a unit to accompany a value",
       "enum": ["feet", "inches", "centimeters", "pounds", "tons", "kilograms"]
-    },,
+    },
     "VehicleImpact": {
       "title": "Vehicle Impact Enumerated Type",
       "description": "The impact to vehicular lanes along a single road in a single direction",

--- a/schemas/v1.1/RoadEventFeature.json
+++ b/schemas/v1.1/RoadEventFeature.json
@@ -294,6 +294,11 @@
       "title": "Unit of Measurement Enumerated Type",
       "description": "Unit of measurement, used when providing a unit to accompany a value",
       "enum": ["feet", "inches", "centimeters", "pounds", "tons", "kilograms"]
+    },,
+    "VehicleImpact": {
+      "title": "Vehicle Impact Enumerated Type",
+      "description": "The impact to vehicular lanes along a single road in a single direction",
+      "enum": ["all-lanes-closed", "some-lanes-closed", "all-lanes-open", "alternating-one-way", "some-lanes-closed-merge-left", "some-lanes-closed-merge-right", "all-lanes-open-shift-left", "all-lanes-open-shift-right", "some-lanes-closed-split", "flagging", "temporary-traffic-signal", "unknown"]
     }
   }
 }

--- a/spec-content/enumerated-types/VehicleImpact.md
+++ b/spec-content/enumerated-types/VehicleImpact.md
@@ -1,0 +1,23 @@
+# VehicleImpact Enumerated Type
+The impact to vehicular lanes along a single road in a single direction.
+
+## Values
+Value | Description
+--- | ---
+`all-lanes-closed` | All lanes are closed
+`some-lanes-closed` | Some lanes are closed
+`all-lanes-open` | All lanes are open
+`alternating-one-way` | The roadway is alternating one way
+`some-lanes-closed-merge-left` | Some lanes merge to the left
+`some-lanes-closed-merge-right` | Some lanes merge to the right
+`all-lanes-open-shift-left` | All lanes are open, shift to the left
+`all-lanes-open-shift-right` | All lanes are open, shift to the right
+`some-lanes-closed-split` | Some lanes end and split & merge to the right and left
+`flagging` | A flagging operation is in effect
+`temporary-traffic-signal` | A temporary traffic signal is in operation
+`unknown` | The vehicle impact is unknown
+
+## Used By
+Property | Object
+--- | ---
+`vehicle_impact` | [RestrictionRoadEvent](/spec-content/objects/RestrictionRoadEvent.md)

--- a/spec-content/objects/RestrictionRoadEvent.md
+++ b/spec-content/objects/RestrictionRoadEvent.md
@@ -11,9 +11,10 @@ Name | Type | Description | Conformance | Notes
 `core_details` | [RoadEventCoreDetails](/spec-content/objects/RoadEventCoreDetails.md) | Describes the basic characterisitics of a road event.  | Required |
 `restrictions` | Array; [[Restriction](/spec-content/objects/Restriction.md)] | A list of zero or more road restrictions that apply to the roadway segment described by this road event. | Conditional: required if `lanes` property is not provided. | Restrictions can also be provided on an individual lane.
 `lanes` | Array; \[[Lane](/spec-content/objects/Lane.md)\] | A list of individual lanes within a road event (roadway segment). | Conditional: required if `restrictions` property is not provided. | Please see [Business Rule](/Creating_a_TDx_Feed.md#business-rules) #2.
+`vehicle_impact` | [VehicleImpact](/spec-content/enumerated-types/VehicleImpact.md) | The impact to vehicular lanes along a single road in a single direction. | Optional |
+
 
 ## Used By
 Property | Object
 --- | ---
 `properties` | [RoadEventFeature](/spec-content/objects/RoadEventFeature.md)
-


### PR DESCRIPTION
## Summary
Add the [VehicleImpact](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/enumerated-types/VehicleImpact.md) property, as-is, to the [RestrictionRoadEvent](https://github.com/usdot-jpo-ode/tdx/blob/main/spec-content/objects/RestrictionRoadEvent.md) object as an *optional* property to maintain backward compatibility.

 ## Motivation
Adding the VehicleImpact property to RestrictionRoadEvent Object lets data publishers inform drivers about how a restriction affects navigation.
